### PR TITLE
Update NeuralNetworkEvaluator.java

### DIFF
--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/NeuralNetworkEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/NeuralNetworkEvaluator.java
@@ -320,7 +320,7 @@ public class NeuralNetworkEvaluator extends ModelEvaluator<NeuralNetwork> implem
 			case LOGISTIC:
 				return 1d / (1d + Math.exp(-z));
 			case TANH:
-				return Math.exp(z);
+				return Math.tanh(z);
 			case IDENTITY:
 				return z;
 			case EXPONENTIAL:


### PR DESCRIPTION
replace (1d - Math.exp(-2d \* z)) / (1d + Math.exp(-2d \* z)) with Math.tanh(z); 

Math.tanh() is a more robust method to calculate the tanh value. For example when z = -512, (1d - Math.exp(-2d \* z)) / (1d + Math.exp(-2d \* z)) will return NAN whileMath.tanh() will return -1.
