### PR TITLE
Allow the computation of averaged class probabilities in pure PMML.

### DIFF
--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/MiningModelEvaluator.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/MiningModelEvaluator.java
@@ -265,9 +265,15 @@ public class MiningModelEvaluator extends ModelEvaluator<MiningModel> implements
 					result.normalizeValues();
 				}
 				break;
-			case MAX:
 			case AVERAGE:
 			case WEIGHTED_AVERAGE:
+				{
+					// Averages and weighted averages of probabilities are probabilities
+					result = new ProbabilityClassificationMap();
+					result.putAll(aggregateProbabilities(segmentation, segmentResults));
+				}
+				break;
+			case MAX:
 				{
 					// The aggregation operation implicitly converts from probabilities to votes
 					result = new ClassificationMap<String>(ClassificationMap.Type.VOTE);


### PR DESCRIPTION
This commit enables the use of `<OutputField feature="probability">` in classification-type MiningModels with `multipleModelMethod="average"` or `"weightedAverage"`.

As you mentioned in https://groups.google.com/d/msg/jpmml/Du0QMIYyvko/LV1wc9fsAFQJ and first implemented in 7a4291cdd335d0193289fe6dbe424287988aa783, certain `multipleModelMethod` aggregations can result in non-probability distributions (i.e. values not summing to 1 or not in the range [0,1]), especially if their inputs are non-probability distributions.  However, averages (and weighted averages with weights summing to 1) of probability distributions are always themselves probability distributions.  This can be shown algebraically:

For a set of n distributions each over m categories, probabilities p_{i,j} have the property that

    sum_{1 <= j <= m} p_{i,j} = 1 for all 1 <= i <= n.   // Eqn 1

Thus, for a set of n weights w_i (canonically equal to 1/n), themselves with the property that

    sum_{1 <= i <= n} w_i = 1,                           // Eqn 2

we have

    sum_{1 <= j <= m} sum_{1 <= i <=n} w_i p_{i,j}       // the sum of the averaged probabilities
    = sum_{1 <= i <= n} (w_i sum_{1 <= j <= m} p_{i,j})  // by the distributive property
    = sum_{1 <= i <= n} w_i                              // by Eqn 1
    = 1                                                  // by Eqn 2

For weighted averages with weights not summing to 1, it can also be shown that normalizing the final result is equivalent to normalizing the weights.

Accordingly, **I would like to request that averages and weighted averages of probability distributions be treated as yielding probability distributions.**  The upshot of this request is that classification-type models with `multipleModelMethod="average"` would be able to yield meaningful OutputFields with `feature="probability"` in pure PMML.  This is important, for example, for obtaining more accurate probability estimates in ensemble methods such as random forests.

The `aggregateProbabilities` function **already normalizes the weights of weighted averages and ensures that its inputs have probability type,** so all code change may be focused on a single case statement.