### PR TITLE
add json serialization to prediction values

### DIFF
--- a/pmml-evaluator/pom.xml
+++ b/pmml-evaluator/pom.xml
@@ -34,6 +34,11 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 
+    <dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/AffinityDistribution.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/AffinityDistribution.java
@@ -27,6 +27,9 @@
  */
 package org.jpmml.evaluator;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -80,6 +83,21 @@ public class AffinityDistribution extends Classification implements HasEntityIdR
 	public Double getEntityAffinity(){
 		return getAffinity(getEntityId());
 	}
+
+  //TODO add?
+  @Override
+  protected JsonElement toJsonHelper(){
+    JsonObject obj    = new JsonObject();
+    JsonObject winner = new JsonObject();
+    String winnerId   = this.getEntityId();
+
+    winner.addProperty(winnerId, this.getAffinity(winnerId));
+
+    obj.addProperty("class", "AffinityDistribution");
+    obj.add("winner", winner);
+
+    return obj;
+  }
 
 	static
 	public Type validateType(Type type){

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/Classification.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/Classification.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
@@ -46,7 +49,6 @@ public class Classification implements Computable {
 	private Object result = null;
 
 	private Type type = null;
-
 
 	public Classification(Type type){
 		setType(type);
@@ -217,6 +219,26 @@ public class Classification implements Computable {
 	private static final Ordering<Double> BIGGER_IS_BETTER = Ordering.<Double>natural();
 	private static final Ordering<Double> SMALLER_IS_BETTER = Ordering.<Double>natural().reverse();
 
+  @Override
+  public String toJson() {
+    return this.toJsonHelper().toString();
+  }
+
+  //TODO necessary?
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    JsonObject entries = new JsonObject();
+
+    for (Map.Entry<String, Double> entry : this.entrySet()){
+      entries.addProperty(entry.getKey(), entry.getValue());
+    }
+
+    obj.addProperty("class", "Classification");
+    obj.addProperty("result", this.getResult().toString());
+    obj.add(this.getType().entryKey(), entries);
+    return obj;
+  }
+
 	static
 	public enum Type implements Comparator<Double> {
 		PROBABILITY(Classification.BIGGER_IS_BETTER, Range.closed(Numbers.DOUBLE_ZERO, Numbers.DOUBLE_ONE)),
@@ -299,5 +321,7 @@ public class Classification implements Computable {
 		private void setRange(Range<Double> range){
 			this.range = range;
 		}
+
+
 	}
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/Computable.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/Computable.java
@@ -18,6 +18,8 @@
  */
 package org.jpmml.evaluator;
 
+import com.google.gson.JsonElement;
+
 /**
  * @see ResultFeature
  */
@@ -27,4 +29,5 @@ public interface Computable {
 	 * @throws UnsupportedOperationException If this object cannot be represented as a Java primitive value.
 	 */
 	Object getResult();
+  String toJson();
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/ProbabilityDistribution.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/ProbabilityDistribution.java
@@ -18,6 +18,9 @@
  */
 package org.jpmml.evaluator;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -40,4 +43,20 @@ public class ProbabilityDistribution extends Classification implements HasProbab
 	public Double getProbability(String value){
 		return get(value);
 	}
+  @Override
+  protected JsonElement toJsonHelper(){
+    JsonObject obj = new JsonObject();
+    JsonObject probabilities = new JsonObject();
+
+    for(String k : this.getCategoryValues()) {
+      probabilities.addProperty(k, this.getProbability(k));
+    }
+
+    obj.addProperty("class", "ProbabilityDistribution");
+    obj.addProperty("result", this.getResult().toString());
+    obj.add("probability_entries", probabilities);
+
+    return obj;
+  }
+
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/VoteDistribution.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/VoteDistribution.java
@@ -18,6 +18,9 @@
  */
 package org.jpmml.evaluator;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -65,4 +68,21 @@ public class VoteDistribution extends Classification implements HasProbability {
 
 		return get(value) / this.sum;
 	}
+
+  @Override
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    JsonObject probabilities = new JsonObject();
+
+    for(String k : this.getCategoryValues()) {
+      probabilities.addProperty(k, this.getProbability(k));
+    }
+
+    obj.addProperty("class", "VoteDistribution");
+    obj.addProperty("result", this.getResult().toString());
+    obj.add("probability_entries", probabilities);
+
+    return obj;
+  }
+
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/association/Association.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/association/Association.java
@@ -23,6 +23,9 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.collect.BiMap;
@@ -140,4 +143,20 @@ public class Association implements Computable, HasRuleValues, HasEntityRegistry
 	private void setConsequentFlags(BitSet consequentFlags){
 		this.consequentFlags = consequentFlags;
 	}
+
+  @Override
+  public String toJson() {
+    return this.toJsonHelper().toString();
+  }
+
+  //TODO
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+
+    obj.addProperty("class", "Association");
+    obj.addProperty("antecedent_flags", this.antecedentFlags.toString());
+    obj.addProperty("consequent_flags", this.consequentFlags.toString());
+
+    return obj;
+  }
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/clustering/ClusterAffinityDistribution.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/clustering/ClusterAffinityDistribution.java
@@ -21,6 +21,9 @@ package org.jpmml.evaluator.clustering;
 import java.util.List;
 import java.util.Set;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import com.google.common.collect.BiMap;
 import org.dmg.pmml.clustering.Cluster;
 import org.jpmml.evaluator.AffinityDistribution;
@@ -67,4 +70,23 @@ public class ClusterAffinityDistribution extends EntityClassification<Cluster> i
 	public Double getEntityAffinity(){
 		return getAffinity(getEntityId());
 	}
+
+  @Override
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    JsonObject affinities = new JsonObject();
+
+    for(String k : this.getCategoryValues()) {
+      affinities.addProperty(k, this.getAffinity(k));
+    }
+
+    obj.addProperty("class", "ClusterAffinityDistribution");
+    obj.addProperty("result", this.getResult().toString());
+    obj.addProperty("display_value", this.getDisplayValue());
+    obj.addProperty("entity_affinity", this.getEntityAffinity());
+    obj.add("affinity_entries", affinities);
+
+    return obj;
+  }
+
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/neural_network/NeuronProbabilityDistribution.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/neural_network/NeuronProbabilityDistribution.java
@@ -20,6 +20,9 @@ package org.jpmml.evaluator.neural_network;
 
 import java.util.Set;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import com.google.common.collect.BiMap;
 import org.dmg.pmml.Entity;
 import org.jpmml.evaluator.EntityClassification;
@@ -40,4 +43,20 @@ public class NeuronProbabilityDistribution extends EntityClassification<Entity> 
 	public Double getProbability(String value){
 		return get(value);
 	}
+
+  @Override
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    JsonObject probabilities = new JsonObject();
+
+    for(String k : this.getCategoryValues()) {
+      probabilities.addProperty(k, this.getProbability(k));
+    }
+
+    obj.addProperty("class", "NeuronProbabilityDistribution");
+    obj.addProperty("result", this.getResult().toString());
+    obj.add("probability_entries", probabilities);
+
+    return obj;
+  }
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/rule_set/SimpleRuleScoreDistribution.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/rule_set/SimpleRuleScoreDistribution.java
@@ -20,6 +20,9 @@ package org.jpmml.evaluator.rule_set;
 
 import java.util.Set;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import com.google.common.collect.BiMap;
 import org.dmg.pmml.DataType;
 import org.dmg.pmml.rule_set.SimpleRule;
@@ -68,4 +71,21 @@ public class SimpleRuleScoreDistribution extends EntityClassification<SimpleRule
 	protected void setEntity(SimpleRule simpleRule){
 		super.setEntity(simpleRule);
 	}
+
+  @Override
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    JsonObject confidences = new JsonObject();
+
+    for(String k : this.getCategoryValues()) {
+      confidences.addProperty(k, this.getConfidence(k));
+    }
+
+    obj.addProperty("class", "SimpleRuleScoreDistribution");
+    obj.addProperty("result", this.getResult().toString());
+    obj.add("confidence_entries", confidences);
+
+    return obj;
+  }
+
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/scorecard/ReasonCodeRanking.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/scorecard/ReasonCodeRanking.java
@@ -21,6 +21,10 @@ package org.jpmml.evaluator.scorecard;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import org.dmg.pmml.MiningFunction;
@@ -75,4 +79,25 @@ public class ReasonCodeRanking implements Computable, HasReasonCodeRanking {
 	private void setReasonCodes(Map<String, Double> reasonCodes){
 		this.reasonCodes = reasonCodes;
 	}
+
+  @Override
+  public String toJson() {
+    return this.toJsonHelper().toString();
+  }
+
+  //TODO
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    JsonArray reasonCodeRankingArray = new JsonArray();
+
+    for (String reasonCode : this.getReasonCodeRanking()) {
+      reasonCodeRankingArray.add(reasonCode);
+    }
+
+    obj.addProperty("class", "ReasonCodeRanking");
+    obj.addProperty("result", this.getResult().toString());
+    obj.add("reason_code_ranking", reasonCodeRankingArray);
+
+    return obj;
+  }
 }

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/tree/NodeScore.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/tree/NodeScore.java
@@ -18,6 +18,9 @@
  */
 package org.jpmml.evaluator.tree;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.collect.BiMap;
@@ -79,6 +82,21 @@ public class NodeScore implements Computable, HasEntityId, HasEntityRegistry<Nod
 
 		return helper.toString();
 	}
+
+  @Override
+  public String toJson() {
+    return this.toJsonHelper().toString();
+  }
+
+  //TODO
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    obj.addProperty("class", "NodeScore");
+    obj.addProperty("result", this.getResult().toString());
+    obj.addProperty("entity_id", this.getEntityId());
+
+    return obj;
+  }
 
 	public Node getNode(){
 		return this.node;

--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/tree/NodeScoreDistribution.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/tree/NodeScoreDistribution.java
@@ -23,6 +23,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.collect.BiMap;
 import org.dmg.pmml.DataType;
@@ -116,4 +119,24 @@ public class NodeScoreDistribution extends EntityClassification<Node> implements
 
 		return helper;
 	}
+
+  @Override
+  protected JsonElement toJsonHelper() {
+    JsonObject obj = new JsonObject();
+    JsonObject probabilities = new JsonObject();
+    JsonObject confidences = new JsonObject();
+
+    for(String k : this.getCategoryValues()) {
+      probabilities.addProperty(k, this.getProbability(k));
+      confidences.addProperty(k, this.getConfidence(k));
+    }
+
+    obj.addProperty("class", "NodeScoreDistribution");
+    obj.addProperty("result", this.getResult().toString());
+    obj.add("probability_entries", probabilities);
+    obj.add("confidence_entries", confidences);
+
+    return obj;
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
 				<version>4.12</version>
 				<scope>test</scope>
 			</dependency>
+
+      <dependency>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>2.8.1</version>
+      </dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
Since the string returned by `toString()` function is not a valid `json` string, it is challenging to give a REST like API using these classes.

This pull request adds `.toJson()` to `Computable` interface, as well as relevant implementations in the classes which implement `Computable`, which then use `.toJsonHelper()` of their respective children classes to create valid json strings from prediction values.

This implementation uses `gson`, and the pull request adds the dependency in the `pom.xml`.