### PR TITLE
add support for BigInteger and BigDecimal

### DIFF
--- a/pmml-evaluator/src/main/java/org/jpmml/evaluator/TypeUtil.java
+++ b/pmml-evaluator/src/main/java/org/jpmml/evaluator/TypeUtil.java
@@ -18,6 +18,8 @@
  */
 package org.jpmml.evaluator;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -579,6 +581,10 @@ public class TypeUtil {
 
 			return Integer.valueOf(number.intValue());
 		}
+		
+		if(value instanceof BigInteger) {
+			return ((BigInteger)value).intValue();
+		}
 
 		throw new TypeCheckException(DataType.INTEGER, value);
 	}
@@ -629,6 +635,14 @@ public class TypeUtil {
 			Number number = (Number)value;
 
 			return toFloat(number.floatValue());
+		}
+		
+		if(value instanceof BigInteger) {
+			return ((BigInteger)value).floatValue();
+		}
+		
+		if(value instanceof BigDecimal) {
+			return ((BigDecimal)value).floatValue();
 		}
 
 		throw new TypeCheckException(DataType.FLOAT, value);
@@ -682,6 +696,14 @@ public class TypeUtil {
 			Number number = (Number)value;
 
 			return toDouble(number.doubleValue());
+		}
+		
+		if(value instanceof BigInteger) {
+			return ((BigInteger)value).doubleValue();
+		}
+		
+		if(value instanceof BigDecimal) {
+			return ((BigDecimal)value).doubleValue();
 		}
 
 		throw new TypeCheckException(DataType.DOUBLE, value);


### PR DESCRIPTION
at the moment it's not possible to provide BigInteger or BigDecimal to the jpmml-evaluator.

This pull request solves this issue.