### PR TITLE
update `org.glassfish.jaxb:codemodel` from 3.0.2 to 4.0.5 and fix break change.

### DIFF
--- a/pmml-evaluator-reporting-processor/pom.xml
+++ b/pmml-evaluator-reporting-processor/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>codemodel</artifactId>
-			<version>3.0.2</version>
+			<version>4.0.5</version>
 		</dependency>
 	</dependencies>
 

--- a/pmml-evaluator-reporting-processor/src/main/java/org/jpmml/evaluator/reporting/processors/OperationProcessor.java
+++ b/pmml-evaluator-reporting-processor/src/main/java/org/jpmml/evaluator/reporting/processors/OperationProcessor.java
@@ -675,11 +675,7 @@ public class OperationProcessor extends AbstractProcessor {
 
 		JType valueClazz;
 
-		try {
-			valueClazz = codeModel.parseType("org.jpmml.evaluator.Value<? extends java.lang.Number>");
-		} catch(ClassNotFoundException cnfe){
-			throw new RuntimeException(cnfe);
-		}
+		valueClazz = codeModel.parseType("org.jpmml.evaluator.Value<? extends java.lang.Number>");
 
 		Matcher matcher = OperationProcessor.PATTERN.matcher(operation);
 
@@ -793,11 +789,8 @@ public class OperationProcessor extends AbstractProcessor {
 			name = name.substring(0, name.length() - "Value<?>".length()) + "Value<? extends java.lang.Number>";
 		}
 
-		try {
-			return codeModel.parseType(name);
-		} catch(ClassNotFoundException cnfe){
-			throw new RuntimeException(cnfe);
-		}
+		return codeModel.parseType(name);
+
 	}
 
 	static


### PR DESCRIPTION
update `org.glassfish.jaxb:codemodel` from 3.0.2 to 4.0.5 and fix break change.